### PR TITLE
[FEAT] : ⚙️ B type : Image + Video 데이터 시간순으로 정렬해서 앱에 표시

### DIFF
--- a/app/src/main/java/com/android/imagesearch/InventoryFragment/InventoryFragmentAdapter.kt
+++ b/app/src/main/java/com/android/imagesearch/InventoryFragment/InventoryFragmentAdapter.kt
@@ -6,12 +6,11 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.android.imagesearch.R
-import com.android.imagesearch.SearchFragment.SearchFragmentAdapter
 import com.android.imagesearch.databinding.BasicBinding
-import com.android.imagesearch.sharedPreferences.ImageSearchData
+import com.android.imagesearch.sharedPreferences.SearchData
 import com.bumptech.glide.Glide
 
-class InventoryFragmentAdapter(private val items : ArrayList<ImageSearchData>, private val context: Context) :
+class InventoryFragmentAdapter(private val items : ArrayList<SearchData>, private val context: Context) :
     RecyclerView
 .Adapter<RecyclerView.ViewHolder>() {
 
@@ -21,7 +20,7 @@ class InventoryFragmentAdapter(private val items : ArrayList<ImageSearchData>, p
     var itemClick:ItemClick? = null
     inner class InventoryViewHolder(private val binding: BasicBinding) : RecyclerView.ViewHolder
         (binding.root){
-        fun bind(items:ImageSearchData){
+        fun bind(items:SearchData){
             binding.apply {
                 SearchName.text = items.display_sitename
                 SearchTime.text = items.datetime

--- a/app/src/main/java/com/android/imagesearch/InventoryFragment/InventoryFrgment.kt
+++ b/app/src/main/java/com/android/imagesearch/InventoryFragment/InventoryFrgment.kt
@@ -9,11 +9,8 @@ import android.view.ViewGroup
 import androidx.fragment.app.setFragmentResult
 import androidx.recyclerview.widget.StaggeredGridLayoutManager
 import com.android.imagesearch.Method.shortToast
-import com.android.imagesearch.R
-import com.android.imagesearch.api.Document
-import com.android.imagesearch.api.Kakao
 import com.android.imagesearch.databinding.FragmentInventoryFrgmentBinding
-import com.android.imagesearch.sharedPreferences.ImageSearchData
+import com.android.imagesearch.sharedPreferences.SearchData
 import com.android.imagesearch.sharedPreferences.SPF
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
@@ -22,9 +19,9 @@ import com.google.gson.reflect.TypeToken
 class InventoryFrgment : Fragment() {
     private val binding by lazy { FragmentInventoryFrgmentBinding.inflate(layoutInflater) }
     private lateinit var spf : SPF
-    private var inventory_items = ArrayList<ImageSearchData>()  //SPF에서 get한 데이터(String)을 넣어주는 리스트
-    private var filter_items = ArrayList<ImageSearchData>()
-    private val favoreitesList = arrayListOf<ImageSearchData>()
+    private var inventory_items = ArrayList<SearchData>()  //SPF에서 get한 데이터(String)을 넣어주는 리스트
+    private var filter_items = ArrayList<SearchData>()
+    private val favoreitesList = arrayListOf<SearchData>()
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -59,7 +56,7 @@ class InventoryFrgment : Fragment() {
         val items = spf.getData()
         Log.d("ImageSearchs","검색결과: ${items}")
         inventory_items = Gson().fromJson(items, object:
-            TypeToken<ArrayList<ImageSearchData>>(){}.type)
+            TypeToken<ArrayList<SearchData>>(){}.type)
         filter_items = ArrayList(inventory_items.filter { it.isLike == true })
         binding.inventoryRecyclerView.apply {
             adapter = InventoryFragmentAdapter(filter_items,requireContext()).apply {

--- a/app/src/main/java/com/android/imagesearch/SearchFragment/SearchFragmentAdapter.kt
+++ b/app/src/main/java/com/android/imagesearch/SearchFragment/SearchFragmentAdapter.kt
@@ -5,13 +5,12 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
-import com.android.imagesearch.Method.shortToast
 import com.android.imagesearch.R
 import com.android.imagesearch.databinding.BasicBinding
-import com.android.imagesearch.sharedPreferences.ImageSearchData
+import com.android.imagesearch.sharedPreferences.SearchData
 import com.bumptech.glide.Glide
 
-class SearchFragmentAdapter(private val items : ArrayList<ImageSearchData>,private val context: Context) :
+class SearchFragmentAdapter(private val items : ArrayList<SearchData>, private val context: Context) :
     RecyclerView
 .Adapter<RecyclerView
 .ViewHolder>() {
@@ -22,9 +21,12 @@ class SearchFragmentAdapter(private val items : ArrayList<ImageSearchData>,priva
     var itemClick:ItemClick? = null
     inner class SearchViewHolder(private val binding:BasicBinding) : RecyclerView.ViewHolder
         (binding.root){
-        fun bind(items:ImageSearchData){
+        fun bind(items:SearchData){
             binding.apply {
-                SearchName.text = items.display_sitename
+                if(items.type == 0){
+                    SearchName.text = "[image]\t\t"+items.display_sitename
+                } else SearchName.text ="[Video]\t\t"+ items.display_sitename
+
                 SearchTime.text = items.datetime
                 Glide.with(context)
                     .load(items.image_url)

--- a/app/src/main/java/com/android/imagesearch/api/NetWorkInterface.kt
+++ b/app/src/main/java/com/android/imagesearch/api/NetWorkInterface.kt
@@ -19,4 +19,3 @@ interface NetWorkInterface {
     ) : VideoData
 }
 
-interface common

--- a/app/src/main/java/com/android/imagesearch/api/NetWorkInterface.kt
+++ b/app/src/main/java/com/android/imagesearch/api/NetWorkInterface.kt
@@ -1,11 +1,20 @@
 package com.android.imagesearch.api
 
+import android.provider.MediaStore.Video
 import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.QueryMap
 
 interface NetWorkInterface {
     @GET("image")
-    suspend fun getImage(@Header("Authorization") authKey: String,
-                         @QueryMap param:HashMap<String,String>) : Kakao
+    suspend fun getImage(
+        @Header("Authorization") authKey: String,
+        @QueryMap param: HashMap<String, String>
+    ): Kakao
+
+    @GET("vclip")
+    suspend fun getVideo(
+        @Header("Authorization") authKey: String,
+        @QueryMap param: HashMap<String, String>
+    ) : VideoData
 }

--- a/app/src/main/java/com/android/imagesearch/api/NetWorkInterface.kt
+++ b/app/src/main/java/com/android/imagesearch/api/NetWorkInterface.kt
@@ -18,3 +18,5 @@ interface NetWorkInterface {
         @QueryMap param: HashMap<String, String>
     ) : VideoData
 }
+
+interface common

--- a/app/src/main/java/com/android/imagesearch/api/VideoData.kt
+++ b/app/src/main/java/com/android/imagesearch/api/VideoData.kt
@@ -1,0 +1,21 @@
+package com.android.imagesearch.api
+
+data class VideoData(
+    val meta : VideoMeta,
+    val document: VideoDocument
+)
+
+data class VideoMeta(
+    val total_count : Int,
+    val pageable_count : Int,
+    val is_end : Boolean
+)
+
+data class VideoDocument(
+    val title : String,
+    val url : String,
+    val datetime: String,
+    val play_time : Int,
+    val thumbnail : String,
+    val author : String
+)

--- a/app/src/main/java/com/android/imagesearch/api/VideoData.kt
+++ b/app/src/main/java/com/android/imagesearch/api/VideoData.kt
@@ -2,7 +2,7 @@ package com.android.imagesearch.api
 
 data class VideoData(
     val meta : VideoMeta,
-    val document: VideoDocument
+    val documents: ArrayList<VideoDocument>
 )
 
 data class VideoMeta(

--- a/app/src/main/java/com/android/imagesearch/api/VideoData.kt
+++ b/app/src/main/java/com/android/imagesearch/api/VideoData.kt
@@ -12,8 +12,8 @@ data class VideoMeta(
 )
 
 data class VideoDocument(
-    val title : String,
     val url : String,
+    val title : String,
     val datetime: String,
     val play_time : Int,
     val thumbnail : String,

--- a/app/src/main/java/com/android/imagesearch/sharedPreferences/SearchData.kt
+++ b/app/src/main/java/com/android/imagesearch/sharedPreferences/SearchData.kt
@@ -1,14 +1,13 @@
 package com.android.imagesearch.sharedPreferences
 
-import android.net.Uri
 import android.os.Parcelable
-import com.android.imagesearch.api.common
 import kotlinx.android.parcel.Parcelize
 
 @Parcelize
-data class ImageSearchData(
+data class SearchData(
+    val type:Int,
     val display_sitename : String,
     val datetime : String,
     val image_url : String,
     var isLike : Boolean = false
-) : Parcelable, common
+) : Parcelable

--- a/app/src/main/java/com/android/imagesearch/sharedPreferences/VideoData.kt
+++ b/app/src/main/java/com/android/imagesearch/sharedPreferences/VideoData.kt
@@ -1,14 +1,13 @@
 package com.android.imagesearch.sharedPreferences
 
-import android.net.Uri
 import android.os.Parcelable
 import com.android.imagesearch.api.common
 import kotlinx.android.parcel.Parcelize
 
 @Parcelize
-data class ImageSearchData(
-    val display_sitename : String,
+data class VideoData(
+    val title : String,
     val datetime : String,
-    val image_url : String,
+    val thumbnail : String,
     var isLike : Boolean = false
 ) : Parcelable, common

--- a/app/src/main/java/com/android/imagesearch/sharedPreferences/VideoData.kt
+++ b/app/src/main/java/com/android/imagesearch/sharedPreferences/VideoData.kt
@@ -1,7 +1,6 @@
 package com.android.imagesearch.sharedPreferences
 
 import android.os.Parcelable
-import com.android.imagesearch.api.common
 import kotlinx.android.parcel.Parcelize
 
 @Parcelize
@@ -10,4 +9,4 @@ data class VideoData(
     val datetime : String,
     val thumbnail : String,
     var isLike : Boolean = false
-) : Parcelable, common
+) : Parcelable

--- a/app/src/main/res/layout/basic.xml
+++ b/app/src/main/res/layout/basic.xml
@@ -42,7 +42,10 @@
                 android:id="@+id/Search_name"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="10dp"/>
+                android:layout_marginStart="10dp"
+                android:textStyle="bold"
+                android:maxLines="1"
+                android:ellipsize="end"/>
         </LinearLayout>
 
         <TextView


### PR DESCRIPTION
1.  VideoData 데이터를 서버클라이언트에서 받아와서 정상적으로 로그 찍힘
2.  Title의 TextView를 최대 한줄만 표시되고 나머지는 ...으로 표시
3.  imageView,Video데이터 모두 앱화면에 표시되게 함. 
:  ㄱ. 처음 데이터를 받아올때 endpoint의 끝자리만 다르기때문에 그 부분만 추가하고 나머지는 기존코드 인용
   ㄴ. 이미지 데이터와 비디오 데이터를 구분하기 위해서 서버클라이언트에서 받아오는데이터에 viewType을 추가했지만 이유를 알 수없는 버그로 재대로 구분이 안됨 
   ㄷ. 데이터(이미지데이터+비디오데이터)를 foreach를 이용해서 새로운 리스트에 추가하는 과정에서 viewType 추가
   ㄹ. 데이터(이미지데이터+비디오데이터)를 시간순으로 정렬 후 어댑터에 넣어줌